### PR TITLE
Delete temporary volume after AMI is built for WS and React deployments

### DIFF
--- a/docs/docs/5-react.md
+++ b/docs/docs/5-react.md
@@ -3,6 +3,12 @@ sidebar_position: 5
 title: React App
 ---
 
+:::tip
+
+- EBS volumes during build time will [automatically be removed][HashiCorp Packer delete_on_termination]
+
+:::
+
 Manual Deployment
 -----------------
 

--- a/docs/docs/6-webservice.md
+++ b/docs/docs/6-webservice.md
@@ -5,7 +5,8 @@ title: Jersey-Jetty Based Webservice
 
 :::tip
 
-Yes, we DO NOT support Spring, never ever
+- Yes, we DO NOT support Spring, never ever
+- EBS volumes during build time will [automatically be removed][HashiCorp Packer delete_on_termination]
 
 :::
 
@@ -117,6 +118,7 @@ jobs:
 [AWS_SECRET_ACCESS_KEY]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
 
 [hashicorp-aws]: https://qubitpi.github.io/hashicorp-aws/
+[HashiCorp Packer delete_on_termination]: https://qubitpi.github.io/hashicorp-packer/packer/integrations/hashicorp/amazon/latest/components/builder/ebs#:~:text=Optional%3A-,delete_on_termination,-(bool)%20%2D%20Indicates%20whether
 [HashiCorp Packer variable file]: https://qubitpi.github.io/hashicorp-packer/packer/guides/hcl/variables#from-a-file
 [HashiCorp Terraform variable file]: https://qubitpi.github.io/hashicorp-terraform/terraform/language/values/variables#variable-definitions-tfvars-files
 

--- a/hashicorp/elk/images/aws-elk.pkr.hcl
+++ b/hashicorp/elk/images/aws-elk.pkr.hcl
@@ -50,12 +50,13 @@ source "amazon-ebs" "elk" {
   ami_name              = "elk"
   force_deregister      = "true"
   force_delete_snapshot = "true"
+  skip_create_ami = "${var.skip_create_ami}"
 
   instance_type = "t2.large"
   region        = "${var.aws_image_region}"
   source_ami_filter {
     filters = {
-      name                = "ubuntu/images/*ubuntu-*-20.04-amd64-server-*"
+      name                = "ubuntu/images/*ubuntu-*-22.04-amd64-server-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }

--- a/hashicorp/mlflow/images/aws-mlflow-docker.pkr.hcl
+++ b/hashicorp/mlflow/images/aws-mlflow-docker.pkr.hcl
@@ -52,7 +52,7 @@ source "amazon-ebs" "mlflow-docker" {
     device_name = "/dev/sda1"
     volume_size = 60
     volume_type = "gp2"
-    delete_on_termination = false
+    delete_on_termination = true
   }
 
   region = "${var.aws_image_region}"

--- a/hashicorp/react/images/aws-react.pkr.hcl
+++ b/hashicorp/react/images/aws-react.pkr.hcl
@@ -22,11 +22,20 @@ variable "ami_name" {
   sensitive = true
 }
 
+variable "instance_type" {
+  type    = string
+  description = "EC2 instance types defined in https://aws.amazon.com/ec2/instance-types/"
+
+  validation {
+    condition     = contains(["t2.micro", "t2.small", "t2.medium", "t2.large", "t2.xlarge", "t2.2xlarge"], var.instance_type)
+    error_message = "Allowed values for input_parameter are those specified for T2 ONLY."
+  }
+}
+
 variable "react_dist_path" {
   type =  string
   sensitive = true
 }
-
 
 variable "aws_react_ssl_cert_file_path" {
   type =  string
@@ -66,12 +75,19 @@ source "amazon-ebs" "react" {
   ami_name = "${var.ami_name}"
   force_deregister = "true"
   force_delete_snapshot = "true"
+  skip_create_ami = "${var.skip_create_ami}"
 
-  instance_type = "t2.small"
+  instance_type = "${var.instance_type}"
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 8
+    volume_type = "gp2"
+    delete_on_termination = true
+  }
   region = "${var.aws_image_region}"
   source_ami_filter {
     filters = {
-      name = "ubuntu/images/*ubuntu-*-20.04-amd64-server-*"
+      name = "ubuntu/images/*ubuntu-*-22.04-amd64-server-*"
       root-device-type = "ebs"
       virtualization-type = "hvm"
     }

--- a/hashicorp/react/instances/aws-react.tf
+++ b/hashicorp/react/instances/aws-react.tf
@@ -22,6 +22,16 @@ variable "ami_name" {
   description = "AMI image name to deploy"
 }
 
+variable "instance_type" {
+  type    = string
+  description = "EC2 instance types defined in https://aws.amazon.com/ec2/instance-types/"
+
+  validation {
+    condition     = contains(["t2.micro", "t2.small", "t2.medium", "t2.large", "t2.xlarge", "t2.2xlarge"], var.instance_type)
+    error_message = "Allowed values for input_parameter are those specified for T2 ONLY."
+  }
+}
+
 variable "ec2_instance_name" {
   type = string
   description = "EC2 instance name"
@@ -81,7 +91,7 @@ data "aws_ami" "latest-aws-react" {
 
 resource "aws_instance" "aws-react" {
   ami = "${data.aws_ami.latest-aws-react.id}"
-  instance_type = "t2.small"
+  instance_type = "${var.instance_type}"
   tags = {
     Name = "${var.ec2_instance_name}"
   }

--- a/hashicorp/webservice/deploy.sh
+++ b/hashicorp/webservice/deploy.sh
@@ -20,6 +20,7 @@ set -e
 cp $HC_CONFIG_DIR/*.properties $WS_DIR/src/main/resources/
 cd $WS_DIR
 mvn clean package
+rm -rf ../../WAR/
 mkdir ../../WAR/
 mv target/*.war ../../WAR
 

--- a/hashicorp/webservice/images/aws-ws.pkr.hcl
+++ b/hashicorp/webservice/images/aws-ws.pkr.hcl
@@ -22,6 +22,16 @@ variable "ami_name" {
   sensitive = true
 }
 
+variable "instance_type" {
+  type        = string
+  description = "EC2 instance types defined in https://aws.amazon.com/ec2/instance-types/"
+
+  validation {
+    condition     = contains(["t2.micro", "t2.small", "t2.medium", "t2.large", "t2.xlarge", "t2.2xlarge"], var.instance_type)
+    error_message = "Allowed values for input_parameter are those specified for T2 ONLY."
+  }
+}
+
 variable "ws_war_path" {
   type =  string
   sensitive = true
@@ -65,8 +75,15 @@ source "amazon-ebs" "ws" {
   ami_name = "${var.ami_name}"
   force_deregister = "true"
   force_delete_snapshot = "true"
+  skip_create_ami = "${var.skip_create_ami}"
 
-  instance_type = "t2.small"
+  instance_type = "${var.instance_type}"
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 8
+    volume_type = "gp2"
+    delete_on_termination = true
+  }
   region = "${var.aws_image_region}"
   source_ami_filter {
     filters = {

--- a/hashicorp/webservice/instances/aws-ws.tf
+++ b/hashicorp/webservice/instances/aws-ws.tf
@@ -22,6 +22,16 @@ variable "ami_name" {
   description = "AMI image name to deploy"
 }
 
+variable "instance_type" {
+  type    = string
+  description = "EC2 instance types defined in https://aws.amazon.com/ec2/instance-types/"
+
+  validation {
+    condition     = contains(["t2.micro", "t2.small", "t2.medium", "t2.large", "t2.xlarge", "t2.2xlarge"], var.instance_type)
+    error_message = "Allowed values for input_parameter are those specified for T2 ONLY."
+  }
+}
+
 variable "ec2_instance_name" {
   type = string
   description = "EC2 instance name"
@@ -90,7 +100,7 @@ data "aws_ami" "latest-ws" {
 
 resource "aws_instance" "aws-ws" {
   ami = "${data.aws_ami.latest-ws.id}"
-  instance_type = "t2.small"
+  instance_type = "${var.instance_type}"
   tags = {
     Name = "${var.ec2_instance_name}"
   }


### PR DESCRIPTION
[//]: # (Copyright Jiaqi Liu)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (    http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Added

### Changed

- A AMI is up-versioning ubuntu to 22.x
- Added AMI & EC2 size parameter

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation

Reference
---------

- [Constrain input variable to require one of a set of allowed values](https://github.com/hashicorp/terraform/issues/25283#issuecomment-646352235)