### PR TITLE
install-data-models doesn't pull data model repo anymore

### DIFF
--- a/auxiliary/github/actions/jersey-webservice-template/jpa-elide/install-data-models/action.yml
+++ b/auxiliary/github/actions/jersey-webservice-template/jpa-elide/install-data-models/action.yml
@@ -25,14 +25,8 @@ inputs:
   model-package-jar-version:
     description: 'The version of JAR containing data models, e.g. "3.1.7"'
     required: true
-  models-repo-token:
-    description: 'The GitHub Fine-grained token with at least "Read access to code and metadata" repository permissions to the data models repo'
-    required: true
-  model-repo-org:
-    description: 'The data models repo owner, e.g. QubitPi'
-    required: true
-  models-repo-name:
-    description: 'The data models repo name, e.g. my-data-models'
+  models-path:
+    description: 'The relative path to the data models repo, usually prefixed by "../". e.g. "../jpa-models"'
     required: true
 
 runs:
@@ -60,6 +54,5 @@ runs:
     - name: Install the data models
       shell: bash
       run: |
-        git clone https://${{ inputs.models-repo-token }}@github.com/${{ inputs.model-repo-org }}/${{ inputs.models-repo-name }}.git ../jpa-models
-        cd ../jpa-models
+        cd ${{ inputs.models-path }}
         mvn clean install

--- a/docs/docs/6-webservice.md
+++ b/docs/docs/6-webservice.md
@@ -163,11 +163,7 @@ jobs:
 - **model-package-jar-group-id** is the Maven group ID of JAR containing data models, e.g. "com.myorg"
 - **model-package-jar-artifact-id** is the Maven artifact ID of JAR containing data models, e.g. "my-data-models"
 - **model-package-jar-version** is the version of JAR containing data models, e.g. "3.1.7"
-- **model-repo-org** is the data models repo owner, e.g. paion-data. This can be eigher a GitHub user account name or
-  a GitHub organization name
-- **models-repo-name** is the data models repo name, e.g. my-data-models
-- **models-repo-token** is the GitHub Fine-grained token with at least "Read access to code and metadata" repository
-  permissions to the data models repo
+- **models-path** is the relative path to the data models repo, usually prefixed by "../". e.g. "../jpa-models"
 
 :::
 
@@ -185,9 +181,7 @@ jobs:
           model-package-jar-group-id: com.myorg
           model-package-jar-artifact-id: my-data-models
           model-package-jar-version: 1.0.0
-          model-repo-org: myorg
-          models-repo-name: my-data-models
-          models-repo-token: ${{ secrets.ASTRAIOS_DATA_MODELS_REPO_TOKEN }}
+          models-path: ../my-data-models
 ```
 
 ##### Docker Compose


### PR DESCRIPTION
[//]: # (Copyright Jiaqi Liu)

[//]: # (Licensed under the Apache License, Version 2.0 &#40;the "License"&#41;;)
[//]: # (you may not use this file except in compliance with the License.)
[//]: # (You may obtain a copy of the License at)

[//]: # (    http://www.apache.org/licenses/LICENSE-2.0)

[//]: # (Unless required by applicable law or agreed to in writing, software)
[//]: # (distributed under the License is distributed on an "AS IS" BASIS,)
[//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
[//]: # (See the License for the specific language governing permissions and)
[//]: # (limitations under the License.)

Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation
